### PR TITLE
Enhance sticky-margin functionality and improve documentation

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -85,12 +85,12 @@ def add(a, b):
 ```
 ````
 
-Then the hide marker, which does not show up in the content but is used to hide the sticky margin figures when it scrolls out of view.
+Then the hide marker, which does not show up in the content but is used to hide the sticky margin elements when it scrolls out of view.
 
 ```{hide-sticky-margin}
 ```
 
-Just above this line the hide marker was added, so when you scroll down and this text reaches the top of the page, all sticky margin figures defined before this line will be hidden. When you scroll back up and this line scrolls back below the header, the sticky margin figures above this line (but after any previous hide marker) will reappear.
+Just above this line the hide marker was added, so when you scroll down and this text reaches the top of the page, all sticky margin elements defined before this line will be hidden. When you scroll back up and this line scrolls back below the header, the sticky margin elements above this line (but after any previous hide marker) will reappear.
 
 Now 10 paragraphs of lorem ipsum to make sure the hide marker scrolls out of view, generated with [Lorem Ipsum](https://www.lipsum.com/):
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -13,21 +13,21 @@
 ```
 ````
 
-# Sticky Margin Figures
+# Sticky Margin Elements
 
 ::::{include} README.md
 :start-after: "# Sphinx Sticky Margin"
 :end-before: "## Installation"
 ::::
 
-## Example
+## Examples
 
-This example shows how to enable sticky margin behavior by adding the `class: sticky-margin` option to a figure.
+This example shows how to enable sticky margin behavior by adding the `:figclass: sticky-margin` option to a figure.
 
 ````md
 ```{figure} /images/TeachBooks_logo.svg
 :name: sticky_basic
-:class: sticky-margin
+:figclass: sticky-margin
 :width: 50%
 
 A figure that moves to the margin after it scrolls out of view.
@@ -36,22 +36,38 @@ A figure that moves to the margin after it scrolls out of view.
 
 ```{figure} /images/TeachBooks_logo.svg
 :name: sticky_basic
-:class: sticky-margin
+:figclass: sticky-margin
 :width: 50%
 
 A figure that moves to the margin after it scrolls out of view.
 ```
 
-Use a hide marker to stop showing all sticky figures after a specific point defined before that point:
+Use a hide marker to stop showing all sticky elements after a specific point defined before that point:
 
 ````md
 ```{hide-sticky-margin}
 ```
 ````
 
-When the hide marker scrolls out of view at the top when scrolling down, all sticky figures defined before that marker will be hidden.
+When the hide marker scrolls out of view at the top when scrolling down, all sticky elements defined before that marker will be hidden.
 
-When scrolling back up, the sticky margin figures above a hide marker (but after any previous hide marker) will reappear when that hide marker scrolls back below the header.
+When scrolling back up, the sticky margin elements above a hide marker (but after any previous hide marker) will reappear when that hide marker scrolls back below the header.
+
+The next code will generate a sticky margin admonition, showing that the sticky margin behavior is not limited to figures but can be applied to any directive that generates an HTML `<div>` element.
+
+````md
+```{admonition} This is a sticky margin admonition
+:class: sticky-margin
+
+This content will appear in the sticky margin when the original element scrolls out of view.
+```
+````
+
+```{admonition} This is a sticky margin admonition
+:class: sticky-margin
+
+This content will appear in the sticky margin when the original element scrolls out of view.
+```
 
 ::::{include} README.md
 :start-after: "## Installation"
@@ -59,7 +75,7 @@ When scrolling back up, the sticky margin figures above a hide marker (but after
 
 ## Additional content
 
-The next content is only added to insert a `hide-sticky-margin` directive to insert a marker, and to show case the scrolling behavior of the sticky margin figures when the hide marker scrolls out of view.
+The next content is only added to insert a `hide-sticky-margin` directive to insert a marker, and to show case the scrolling behavior of the sticky margin elements when the hide marker scrolls out of view.
 
 First some filler code:
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -70,7 +70,7 @@ This content will appear in the sticky margin when the original element scrolls 
 ```
 
 ::::{include} README.md
-:start-after: "## Installation"
+:start-after: "<!-- Install start -->"
 ::::
 
 ## Additional content

--- a/README.md
+++ b/README.md
@@ -31,21 +31,48 @@ sphinx:
 
 ## Usage
 
+### Enabling Sticky Margin Behavior
+
 Add the option `:figclass: sticky-margin` to a `figure` directive that should get a sticky margin clone. (For backward compatibility, `:class: sticky-margin` also works for `figure` directives.)
 
 Add the option `:class: sticky-margin` to a directive that generates an HTML `<div>` element that should get a sticky margin clone.
 
 Add the option `:class: sticky-margin` to a `image` directive that should get a sticky margin clone.
 
-Insert a `hide-sticky-margin` directive to insert a marker after which to fade out the last sticky elements during scrolling.
-
 The sticky margin elements will appear when the original element scrolls out of view, and will disappear when the original element comes back into view.
 
-In case of multiple sticky margin elements, all will be shown in the margin.
+In case of multiple (active) sticky margin elements, all will be shown in the margin.
+
+### Disabling Sticky Margin Behavior
+
+Insert a `hide-sticky-margin` directive to insert a marker after which to fade out the last sticky elements during scrolling.
 
 If a hide marker scrolls out of view at the top when scrolling down, all sticky elements defined before that marker will be hidden.
 
 When scrolling back up, the sticky margin elements above a hide marker (but after any previous hide marker) will reappear when that hide marker scrolls back below the header.
+
+### Sticky Margin Behavior
+
+By _default_ the sticky margin element will appear when the original element is fully scrolled out of view, and will disappear when the original element is partially back in view.
+
+In `partial` mode, the sticky margin element will appear when the original element is partially scrolled out of view, and will disappear when the original element is fully back in view.
+
+To set the sticky margin trigger mode, add the following to `conf.py`:
+
+```python
+sticky_margin["trigger"] = "partial"  # or "full"
+```
+
+Or for Jupyter Book (`_config.yml`):
+
+```yaml
+sphinx:
+  config:
+    sticky_margin:
+      trigger: partial  # or full
+```
+
+If any value other than `partial` or `full` is set, the extension will fall back to the default `full` mode with a warning.
 
 ### MyST Example
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,22 @@ sphinx:
 
 If any value other than `partial` or `full` is set, the extension will fall back to the default `full` mode with a warning.
 
- > [!CAUTION]
- > The order of the elements in the margin is determined by the order in which they are present in the DOM, however the trigger works on the actual rendered position of the original element. This means that if two elements are visually side-by-side, but if the second DOM element ends/starts higher in the rendering, the second element will trigger before the first one. As soon as the first DOM element also causes the trigger, both elements will be shown in the margin, and the order of the elements in the margin will be determined by their order in the DOM, which cause the margin element of the second DOM element to be "pushed down" by the margin element of the first DOM element.
+The order of the elements in the margin is determined by the order in which they are rendered and the trigger works on the actual rendered position of the original element. For `full` trigger mode, the sort order is:
+1. bottom (smallest first)
+2. top (smallest first)
+3. left (smallest first)
+4. height (smallest first)
+5. width (smallest first)
+6. DOM order (fallback)
+
+For `partial` trigger mode, the sort order is:
+
+1. top (smallest first)
+2. bottom (smallest first)
+3. left (smallest first)
+4. height (smallest first)
+5. width (smallest first)
+6. DOM order (fallback)
 
   > [!NOTE]
  > The combination of `:class: sticky-margin, dropdown` is not supported, as the dropdown behavior conflicts with the sticky margin behavior. If both classes are present, the `sticky-margin` class will be removed and a warning will be issued in the console.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ sphinx:
 
 If any value other than `partial` or `full` is set, the extension will fall back to the default `full` mode with a warning.
 
+ > [!CAUTION]
+ > The order of the elements in the margin is determined by the order in which they are present in the DOM, however the trigger works on the actual rendered position of the original element. This means that if two elements are visually side-by-side, but if the second DOM element ends/starts higher in the rendering, the second element will trigger before the first one. As soon as the first DOM element also causes the trigger, both elements will be shown in the margin, and the order of the elements in the margin will be determined by their order in the DOM, which cause the margin element of the second DOM element to be "pushed down" by the margin element of the first DOM element.
+
+  > [!NOTE]
+ > The combination of `:class: sticky-margin, dropdown` is not supported, as the dropdown behavior conflicts with the sticky margin behavior. If both classes are present, the `sticky-margin` class will be removed and a warning will be issued in the console.
+
 ### MyST Example
 
 ````md

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Sphinx Sticky Margin
 
-`sphinx-sticky-margin` is a Sphinx extension that adds a sticky margin copy for figures marked with the `:class: sticky-margin` option.
+`sphinx-sticky-margin` is a Sphinx extension that adds a sticky margin copy for images, figures and other elements marked using the class `sticky-margin`.
 
-When the original figure scrolls above the header, a duplicate appears in the right margin (on wide screens). When the original figure comes back into view, the margin copy is hidden.
+When the original element scrolls above the header, a duplicate appears in the right margin (on wide screens). When the original element comes back into view, the margin copy is hidden.
 
 ## Installation
 
@@ -30,23 +30,27 @@ sphinx:
 
 ## Usage
 
-Add the `:class: sticky-margin` class to figures that should get a sticky margin clone.
+Add the option `:figclass: sticky-margin` to a `figure` directive that should get a sticky margin clone. (For backward compatibility, `:class: sticky-margin` also works for `figure` directives.)
 
-Insert a `hide-sticky-margin` directive to insert a marker after which to fade out the last sticky figure during scrolling.
+Add the option `:class: sticky-margin` to a directive that generates an HTML `<div>` element that should get a sticky margin clone.
 
-The sticky margin figure will appear when the original figure scrolls out of view, and will disappear when the original figure comes back into view.
+Add the option `:class: sticky-margin` to a `image` directive that should get a sticky margin clone.
 
-In case of multiple sticky margin figures, all will be shown in the margin.
+Insert a `hide-sticky-margin` directive to insert a marker after which to fade out the last sticky elements during scrolling.
 
-If a hide marker scrolls out of view at the top when scrolling down, all sticky figures defined before that marker will be hidden.
+The sticky margin elements will appear when the original element scrolls out of view, and will disappear when the original element comes back into view.
 
-When scrolling back up, the sticky margin figures above a hide marker (but after any previous hide marker) will reappear when that hide marker scrolls back below the header.
+In case of multiple sticky margin elements, all will be shown in the margin.
+
+If a hide marker scrolls out of view at the top when scrolling down, all sticky elements defined before that marker will be hidden.
+
+When scrolling back up, the sticky margin elements above a hide marker (but after any previous hide marker) will reappear when that hide marker scrolls back below the header.
 
 ### MyST Example
 
 ````md
 ```{figure} path/to/image.png
-:class: sticky-margin
+:figclass: sticky-margin
 
 Figure caption.
 ```
@@ -56,7 +60,7 @@ Figure caption.
 
 ```rst
 .. figure:: path/to/image.png
-   :class: sticky-margin
+   :figclass: sticky-margin
 
    Figure caption.
 ```
@@ -68,11 +72,29 @@ Figure caption.
 ```
 ````
 
-When the marker scrolls above the header, the previous sticky margin figure is hidden with a fade-out.
+### Images
+
+````md
+```{image} path/to/image.png
+:class: sticky-margin
+```
+````
+
+### Directives with `:class: sticky-margin`
+
+````md
+```{admonition} This is a sticky margin admonition
+:class: sticky-margin
+
+This content will appear in the sticky margin when the original element scrolls out of view.
+```
+````
+
+When the marker scrolls above the header, the previous sticky margin elements are hidden with a fade-out.
 
 ## Notes
 
 - The sticky margin display is active from `1200px` viewport width and up.
 - The extension injects `sticky-margin.css` and `sticky-margin.js`.
-- MathJax content inside sticky figures is re-typeset when needed.
+- MathJax content inside sticky elements is re-typeset when needed.
 - The extension removes explicit line endings (`<br>`, double space in markdown) from figure captions to prevent layout issues in the margin.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 When the original element scrolls above the header, a duplicate appears in the right margin (on wide screens). When the original element comes back into view, the margin copy is hidden.
 
+<!-- Install start -->
 ## Installation
 
 ```bash

--- a/src/sphinx_sticky_margin/__init__.py
+++ b/src/sphinx_sticky_margin/__init__.py
@@ -1,6 +1,6 @@
 """Sphinx Sticky Margin extension.
 
-Adds frontend assets that duplicate figures with ``:class: sticky-margin``
+Adds frontend assets that duplicate elements with ``:(fig)class: sticky-margin``
 into the right margin while scrolling.
 """
 
@@ -13,13 +13,14 @@ from docutils import nodes
 from docutils.parsers.rst import Directive
 from sphinx.application import Sphinx
 from sphinx.util.fileutil import copy_asset
-
+from sphinx.util import logging
 
 try:
     from ._version import version as __version__
 except Exception:  # pragma: no cover - generated at build time
     __version__ = "0+unknown"
 
+logger = logging.getLogger(__name__)
 
 class HideStickyMarginDirective(Directive):
     """Insert a marker that hides the previous sticky margin figure when passed."""
@@ -47,6 +48,23 @@ def _copy_asset_files(app: Sphinx, exception: Optional[Exception]) -> None:
     copy_asset(str(asset_dir / "sticky-margin.css"), str(out_static_dir))
     copy_asset(str(asset_dir / "sticky-margin.js"), str(out_static_dir))
 
+def set_config(app: Sphinx, config) -> None:
+    """Check and write the config value for the extension to JS."""
+
+    cfg = dict(app.config.sticky_margin)
+    if not cfg:
+        cfg = {"trigger": "full"}
+    if "trigger" not in cfg:
+        cfg["trigger"] = "full"
+    else:
+        if cfg["trigger"] not in ("partial", "full"):
+            logger.warning(f"Invalid value for sticky_margin.trigger: {cfg['trigger']!r}, expected 'partial' or 'full'. Defaulting to 'full'.")
+            cfg["trigger"] = "full"
+
+    app.add_js_file(None, body=f"let stickyMarginTrigger = {cfg['trigger']!r};")
+
+    
+
 
 def setup(app: Sphinx) -> dict[str, object]:
     """Register the extension with Sphinx."""
@@ -54,6 +72,8 @@ def setup(app: Sphinx) -> dict[str, object]:
     app.add_js_file("sticky-margin.js")
     app.add_directive("hide-sticky-margin", HideStickyMarginDirective)
     app.connect("build-finished", _copy_asset_files)
+    app.add_config_value("sticky_margin", {}, "html")
+    app.connect("config-inited",set_config)
 
     return {
         "version": __version__,

--- a/src/sphinx_sticky_margin/assets/sticky-margin.js
+++ b/src/sphinx_sticky_margin/assets/sticky-margin.js
@@ -213,6 +213,12 @@ document.addEventListener('DOMContentLoaded', function () {
   document.querySelectorAll('.sticky-margin').forEach(function (marker) {
     var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
+    if (marker.classList && marker.classList.contains('dropdown')) {
+      marker.classList.remove('sticky-margin');
+      console.log('Warning: Element with both "sticky-margin" and "dropdown" classes found. "sticky-margin" class has been removed to avoid conflicts between behaviors.', marker);
+      return;
+    }
+
     var mainFigure = marker;
     if (marker.tagName === 'FIGURE') {
       mainFigure = marker;

--- a/src/sphinx_sticky_margin/assets/sticky-margin.js
+++ b/src/sphinx_sticky_margin/assets/sticky-margin.js
@@ -207,7 +207,15 @@ document.addEventListener('DOMContentLoaded', function () {
   document.querySelectorAll('.sticky-margin').forEach(function (marker) {
     var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    var mainFigure = marker.tagName === 'FIGURE' ? marker : marker.closest('figure');
+    var mainFigure = marker;
+    if (marker.tagName === 'FIGURE') {
+      mainFigure = marker;
+    } else if (marker.tagName === 'DIV') {
+      // Allow standalone or nested div.sticky-margin blocks to be sticky on their own.
+      mainFigure = marker;
+    } else {
+      mainFigure = marker.closest('figure') || marker;
+    }
 
     if (!mainFigure || handledFigures.has(mainFigure)) return;
     handledFigures.add(mainFigure);

--- a/src/sphinx_sticky_margin/assets/sticky-margin.js
+++ b/src/sphinx_sticky_margin/assets/sticky-margin.js
@@ -291,8 +291,8 @@ document.addEventListener('DOMContentLoaded', function () {
       });
     }
 
-    var sourceImage = mainFigure.querySelector('.sticky-margin') || mainFigure.querySelector('img');
-    var targetImage = aside.querySelector('img');
+    var sourceFlightElement = mainFigure;
+    var targetFlightElement = aside.querySelector('figure') || aside.firstElementChild;
     var hideMarker = getNextHideMarker(mainFigure);
     var lastSourceRect = null;
     var currentFlightAnimation = null;
@@ -363,9 +363,9 @@ document.addEventListener('DOMContentLoaded', function () {
       return visibilityToken;
     }
 
-    function createFlightClone(image, rect) {
-      var clone = image.cloneNode(true);
-      clone.className = image.className;
+    function createFlightClone(element, rect) {
+      var clone = element.cloneNode(true);
+      clone.className = element.className;
       clone.classList.add('sticky-margin-flight');
       clone.style.left = rect.left + 'px';
       clone.style.top = rect.top + 'px';
@@ -451,9 +451,9 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function rememberSourceRect() {
-      if (!sourceImage || window.innerWidth < 1200 || !isFigureRenderedAndVisible()) return;
+      if (!sourceFlightElement || window.innerWidth < 1200 || !isFigureRenderedAndVisible()) return;
 
-      var rect = sourceImage.getBoundingClientRect();
+      var rect = sourceFlightElement.getBoundingClientRect();
       if (rect.bottom > 0 && rect.top < window.innerHeight && rect.width > 0 && rect.height > 0) {
         lastSourceRect = rect;
       }
@@ -557,8 +557,8 @@ document.addEventListener('DOMContentLoaded', function () {
       if (
         prefersReducedMotion ||
         !allowFlightAnimation ||
-        !sourceImage ||
-        !targetImage ||
+        !sourceFlightElement ||
+        !targetFlightElement ||
         !lastSourceRect ||
         window.innerWidth < 1200
       ) {
@@ -568,8 +568,8 @@ document.addEventListener('DOMContentLoaded', function () {
         return;
       }
 
-      aside.classList.add('is-preparing');
-      var targetRect = targetImage.getBoundingClientRect();
+        aside.classList.add('is-preparing');
+        var targetRect = targetFlightElement.getBoundingClientRect();
 
       if (targetRect.width === 0 || targetRect.height === 0) {
         aside.classList.remove('is-preparing');
@@ -579,7 +579,7 @@ document.addEventListener('DOMContentLoaded', function () {
         return;
       }
 
-      var clone = createFlightClone(sourceImage, lastSourceRect);
+      var clone = createFlightClone(sourceFlightElement, lastSourceRect);
 
       animateFlight(clone, lastSourceRect, targetRect, function () {
         if (showToken !== visibilityToken) {
@@ -606,7 +606,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
       cancelPendingHide();
       cancelCurrentFlight();
-
       if (aside.classList.contains('is-preparing')) {
         aside.classList.remove('is-preparing');
         aside.classList.remove('is-visible');
@@ -614,7 +613,7 @@ document.addEventListener('DOMContentLoaded', function () {
         return;
       }
 
-      if (prefersReducedMotion || !sourceImage || !targetImage || window.innerWidth < 1200) {
+      if (prefersReducedMotion || !sourceFlightElement || !targetFlightElement || window.innerWidth < 1200) {
         aside.classList.remove('is-visible');
         aside.style.opacity = '1';
         return;

--- a/src/sphinx_sticky_margin/assets/sticky-margin.js
+++ b/src/sphinx_sticky_margin/assets/sticky-margin.js
@@ -367,7 +367,11 @@ document.addEventListener('DOMContentLoaded', function () {
       }
 
       if (currentFlightClone) {
+        var flightWrapper = currentFlightClone.parentElement;
         currentFlightClone.remove();
+        if (flightWrapper && flightWrapper.classList.contains('sticky-margin-flight-context')) {
+          flightWrapper.remove();
+        }
         currentFlightClone = null;
       }
     }
@@ -386,7 +390,17 @@ document.addEventListener('DOMContentLoaded', function () {
       clone.style.width = rect.width + 'px';
       clone.style.height = rect.height + 'px';
       clone.style.boxShadow = 'none';
-      document.body.appendChild(clone);
+
+      // Wrap in a sidebar context element so that CSS rules scoped to
+      // .bd-sidebar-secondary (e.g. font-size) cascade into the clone
+      // during the flight animation.
+      var sidebarEl = document.querySelector('#pst-secondary-sidebar');
+      var contextClasses = sidebarEl ? sidebarEl.className : 'bd-sidebar-secondary bd-toc';
+      var wrapper = document.createElement('div');
+      wrapper.className = contextClasses + ' sticky-margin-flight-context';
+      wrapper.style.cssText = 'position:fixed;left:0;top:0;width:0;height:0;overflow:visible;pointer-events:none;';
+      wrapper.appendChild(clone);
+      document.body.appendChild(wrapper);
       return clone;
     }
 
@@ -418,7 +432,11 @@ document.addEventListener('DOMContentLoaded', function () {
       currentFlightAnimation = animation;
 
       function cleanup() {
+        var flightWrapper = clone.parentElement;
         clone.remove();
+        if (flightWrapper && flightWrapper.classList.contains('sticky-margin-flight-context')) {
+          flightWrapper.remove();
+        }
         currentFlightAnimation = null;
         if (currentFlightClone === clone) {
           currentFlightClone = null;

--- a/src/sphinx_sticky_margin/assets/sticky-margin.js
+++ b/src/sphinx_sticky_margin/assets/sticky-margin.js
@@ -36,7 +36,8 @@ document.addEventListener('DOMContentLoaded', function () {
     var scrollY = window.scrollY || window.pageYOffset || 0;
 
     return {
-      // Sticky activation uses figure bottom crossing the header, so bottom Y is
+      // Sticky activation uses figure bottom (in full trigger mode) or top (in partial trigger mode)
+      // crossing the header, so bottom Y or top Y, respectively, is
       // the most natural ordering key for rendered behavior.
       bottom: rect.bottom + scrollY,
       top: rect.top + scrollY,
@@ -55,11 +56,21 @@ document.addEventListener('DOMContentLoaded', function () {
       var aMetrics = getFigureSortMetrics(a.mainFigure);
       var bMetrics = getFigureSortMetrics(b.mainFigure);
 
-      if (aMetrics.bottom !== bMetrics.bottom) {
-        return aMetrics.bottom - bMetrics.bottom;
+      if (stickyTriggerMode === 'full') {
+        if (aMetrics.bottom !== bMetrics.bottom) {
+          return aMetrics.bottom - bMetrics.bottom;
+        }
+        if (aMetrics.top !== bMetrics.top) {
+          return aMetrics.top - bMetrics.top;
+        }
       }
-      if (aMetrics.top !== bMetrics.top) {
-        return aMetrics.top - bMetrics.top;
+      if (stickyTriggerMode === 'partial') {
+        if (aMetrics.top !== bMetrics.top) {
+          return aMetrics.top - bMetrics.top;
+        }
+        if (aMetrics.bottom !== bMetrics.bottom) {
+          return aMetrics.bottom - bMetrics.bottom;
+        }
       }
       if (aMetrics.left !== bMetrics.left) {
         return aMetrics.left - bMetrics.left;

--- a/src/sphinx_sticky_margin/assets/sticky-margin.js
+++ b/src/sphinx_sticky_margin/assets/sticky-margin.js
@@ -7,6 +7,12 @@ document.addEventListener('DOMContentLoaded', function () {
   var hideMarkers = Array.prototype.slice.call(
     document.querySelectorAll('.hide-sticky-margin-marker')
   );
+  var stickyTriggerMode = (
+    typeof stickyMarginTrigger === 'string' ? stickyMarginTrigger.toLowerCase() : 'full'
+  );
+  if (stickyTriggerMode !== 'partial' && stickyTriggerMode !== 'full') {
+    stickyTriggerMode = 'full';
+  }
 
   function compareFigureDocumentOrder(a, b) {
     if (a === b) {
@@ -499,7 +505,10 @@ document.addEventListener('DOMContentLoaded', function () {
       }
 
       var rect = mainFigure.getBoundingClientRect();
-      if (rect.bottom >= headerHeight) {
+      var isAboveHeaderThreshold = stickyTriggerMode === 'partial'
+        ? rect.top < headerHeight
+        : rect.bottom < headerHeight;
+      if (!isAboveHeaderThreshold) {
         return false;
       }
 
@@ -646,7 +655,10 @@ document.addEventListener('DOMContentLoaded', function () {
       rememberSourceRect();
       updateStickyTopOffset();
 
-      if (aside.classList.contains('is-preparing') || aside.classList.contains('is-visible')) {
+      var shouldEvaluateOnScroll = stickyTriggerMode === 'partial' ||
+        aside.classList.contains('is-preparing') ||
+        aside.classList.contains('is-visible');
+      if (shouldEvaluateOnScroll) {
         evaluateStickyVisibility();
       }
     }, { passive: true });


### PR DESCRIPTION
Functionality added:

- Sticky margin elements now work for images within figures, figures without images, images outside figures and directives.
- Behaviour when scrolling can be set to `full` ("margin element appears when original element disappears above the header") or to `partial` ("margin element appears when original element reaches the header") and corresponding disappearing behavior.